### PR TITLE
Fixes for non-English account language on Steam

### DIFF
--- a/farmer.js
+++ b/farmer.js
@@ -142,7 +142,7 @@ function checkMinPlaytime() {
 				});
 				
 				// Find out if we have drops left
-				var drops = row.find('.progress_info_bold').text().match(/(\d+) card drops? remaining/);
+				var drops = row.find('.progress_info_bold').text().match(/(\d+)/);
 				if(!drops) {
 					return;
 				}
@@ -153,7 +153,7 @@ function checkMinPlaytime() {
 				}
 				
 				// Find out playtime
-				var playtime = row.find('.badge_title_stats').html().match(/(\d+\.\d+) hrs on record/);
+				var playtime = row.find('.badge_title_stats').html().match(/(\d+\.\d+)/);
 				if(!playtime) {
 					playtime = 0.0;
 				} else {
@@ -315,7 +315,7 @@ function checkCardApps() {
 			var infolines = $('.progress_info_bold');
 			
 			for(var i = 0; i < infolines.length; i++) {
-				var match = $(infolines[i]).text().match(/(\d+) card drops? remaining/);
+				var match = $(infolines[i]).text().match(/(\d+)/);
 				
 				var href = $(infolines[i]).closest('.badge_row').find('.badge_title_playgame a').attr('href');
 				if(!href) {


### PR DESCRIPTION
If user account language other than English regular expressions do not work and farmer believes that no games with cards.